### PR TITLE
improve empty check

### DIFF
--- a/Alley/URLSession-extensions.swift
+++ b/Alley/URLSession-extensions.swift
@@ -103,7 +103,7 @@ private extension URLSession {
 			return .failure( NetworkError.endpointError(httpURLResponse, data) )
 		}
 
-		guard let data = data, data.count > 0 else {
+        guard let data = data, !data.isEmpty else {
 			if allowEmptyData {
 				return .success(Data())
 			}


### PR DESCRIPTION
From the [documentation](https://developer.apple.com/documentation/foundation/data/1780284-isempty#):

> When you need to check whether your collection is empty, use the isEmpty property instead of checking that the count property is equal to zero.
> Complexity: O(1)